### PR TITLE
Remove unnecessary [{topic}] tag

### DIFF
--- a/dzslides.conf
+++ b/dzslides.conf
@@ -66,11 +66,13 @@ options=sectionbody
 posattrs=style
 
 [sect1]
-<section{role? class="{role}"}>
+# All topic roles contains "topic", no need for [{topic}]
+<section class="topic{role? {role}}">
 #<h2{hrole? class="{hrole}"}>{title}</h2>
 # title value can't be matched against anything, perhaps a bug?
 #{title@SLIDE:0}<h2{hrole? class="{hrole}"}>{title}</h2>
-{role$(.* )?topic( .*)?:}<h2{hrole? class="{hrole}"}>{title}</h2>
+#{role$(.* )?topic( .*)?:}<h2{hrole? class="{hrole}"}>{title}</h2>
+<h2{id? class="{id}"}>{title}</h2>
 |
 </section>
 


### PR DESCRIPTION
The "[{topic}]" tag before [sect1] is not needed. All topic roles
contain the same word, and is now the default. Thus, all [sect1]
titles have the "topic" tag as default.
