### PR TITLE
Update dzslides.conf

### DIFF
--- a/dzslides.conf
+++ b/dzslides.conf
@@ -193,6 +193,8 @@ include1::{dzslidesdir=./dzslides}/highlight/highlight.pack.js[]
     </script>
 endif::dzslides-highlight[]
 endif::linkcss[]
+ifdef::dzslides-highlight[]
     <script>hljs.initHighlightingOnLoad();</script>
+endif::dzslides-highlight[]
   </body>
 </html>


### PR DESCRIPTION
Highlighting should only init if it's in use.
